### PR TITLE
EfficiencyCI.xs: include eff_ci.h to compile under -Werror

### DIFF
--- a/EfficiencyCI.xs
+++ b/EfficiencyCI.xs
@@ -7,8 +7,9 @@
 #include <float.h>
 #include <math.h>
 #include "eff_math_fun.h"
+#include "eff_ci.h" /* for efficiency_ci() */
 
-MODULE = Statistics::EfficiencyCI		PACKAGE = Statistics::EfficiencyCI		
+MODULE = Statistics::EfficiencyCI		PACKAGE = Statistics::EfficiencyCI
 
 
 void


### PR DESCRIPTION
Originally reported here:
https://rt.cpan.org/Public/Bug/Display.html?id=133406

Just noticed there's a github repo!